### PR TITLE
Remove isarray dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,6 @@
  * Module requirements.
  */
 
-var isArray = require('isarray');
-
 var toString = Object.prototype.toString;
 var withNativeBlob = typeof global.Blob === 'function' || toString.call(global.Blob) === '[object BlobConstructor]';
 var withNativeFile = typeof global.File === 'function' || toString.call(global.File) === '[object FileConstructor]';
@@ -30,7 +28,7 @@ function hasBinary (obj) {
     return false;
   }
 
-  if (isArray(obj)) {
+  if (Array.isArray(obj)) {
     for (var i = 0, l = obj.length; i < l; i++) {
       if (hasBinary(obj[i])) {
         return true;

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "has-binary2",
   "version": "1.0.2",
   "description": "A function that takes anything in javascript and returns true if its argument contains binary data.",
-  "dependencies": {
-    "isarray": "2.0.1"
-  },
   "devDependencies": {
     "better-assert": "^1.0.2",
     "mocha": "^3.2.0",


### PR DESCRIPTION
Hi there! When running `npm install` in a project that relies on `has-binary`, a warning is being displayed:
> warning your-project > has-binary2 > isarray@2.0.1: Just use Array.isArray directly

This PR gets rid of this warning by removing the `isarray` dependency and replacing it with `Array.isArray`. As a side effect `has-binary` is now dependency-free!