### PR TITLE
Use isarray as a bundled dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "has-binary2",
   "version": "1.0.2",
   "description": "A function that takes anything in javascript and returns true if its argument contains binary data.",
-  "dependencies": {
-    "isarray": "2.0.1"
-  },
+  "bundledDependencies": [
+    "isarray"
+  ],
   "devDependencies": {
     "better-assert": "^1.0.2",
     "mocha": "^3.2.0",


### PR DESCRIPTION
As discussed in https://github.com/darrachequesne/has-binary/pull/1.

This should get rid of the deprecation notice of `isarray` when installing `has-binary2`.